### PR TITLE
Add _config.py for global config

### DIFF
--- a/datakyt/_config.py
+++ b/datakyt/_config.py
@@ -1,0 +1,13 @@
+_global_config = {'db_name': 'datakyt',
+                  'db_admin': 'datakyt_admin',
+                  'db_password': ''}
+
+
+def get_config() -> dict:
+    return _global_config.copy()
+
+
+def set_config(params: dict):
+    for param, value in params.items():
+        if value is not None:
+            _global_config[param] = value

--- a/datakyt/_config.py
+++ b/datakyt/_config.py
@@ -4,10 +4,26 @@ _global_config = {'db_name': 'datakyt',
 
 
 def get_config() -> dict:
+    """Retrieve current values for configuration set by :func:`set_config`
+    Returns
+    -------
+    config : dict
+        Keys are config names that can be passed to :func:`set_config`.
+    """
     return _global_config.copy()
 
 
 def set_config(params: dict):
+    """Set global datakyt configuration
+    Parameters
+    ----------
+    params : dict
+        If None passed as a new config value, _global_config won't be changed.
+        If an existing config name was passed as a dict key with a not-None value, the corresponded
+        config in _global_config will be changed to passed value.
+        If non-existing config name was passed as a dict key with a not-None value, the new config
+        will be created in _global_config.
+    """
     if type(params) is not dict:
         raise TypeError(f"Dict expected, got {type(params)} instead")
     for param, value in params.items():

--- a/datakyt/_config.py
+++ b/datakyt/_config.py
@@ -8,6 +8,8 @@ def get_config() -> dict:
 
 
 def set_config(params: dict):
+    if type(params) is not dict:
+        raise TypeError(f"Dict expected, got {type(params)} instead")
     for param, value in params.items():
         if value is not None:
             _global_config[param] = value


### PR DESCRIPTION
# What does this PR do?

Add _config.py for global config

## Issue reference

Fixes #17

## Explanation

Add _config.py with project global config in a python dictionary format with such configs: db_name, db_admin, db_password.
